### PR TITLE
Adiciona workflow para gerar release automática com versão do build.gradle

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,34 @@
+name: Gerar Release Automática
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+
+jobs:
+  gerar_release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout do código
+        uses: actions/checkout@v3
+
+      - name: Ler versão do build.gradle
+        id: tag
+        run: |
+          VERSION=$(grep '^version =' build.gradle | sed "s/version = ['\"]\(.*\)['\"]/\\1/")
+          echo "tag=v$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Mostrar tag criada
+        run: |
+          echo "Tag gerada: ${{ steps.tag.outputs.tag }}"
+
+      - name: Criar release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.tag.outputs.tag }}
+          name: "Release ${{ steps.tag.outputs.tag }}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Este PR adiciona um workflow que gera uma release automática sempre que um push é feito na branch main. A versão usada é lida do arquivo build.gradle.
